### PR TITLE
Branch mget

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,15 @@
       "name": "David Chancogne",
       "email": "dchancogne@traackr.com",
       "homepage": "http://twitter.com/dchancogne"
+    },
+    {
+      "name": "Rajiv Ramaiah",
+      "email": "rramaiah@traackr.com"
+    },
+    {
+      "name": "Luis A. Cruz",
+      "email": "lcruz@traackr.com",
+      "homepage": "http://twitter.com/sprak"
     }
   ],
   "require": {
@@ -24,7 +33,7 @@
   "require-dev": {
     "phpunit/phpunit": "3.7.*",
     "cakephp/cakephp": "2.4.5",
-    "m6web/redis-mock": "v2.1.0"
+    "m6web/redis-mock": "v2.3.0"
   },
   "config": {
     "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   "require-dev": {
     "phpunit/phpunit": "3.7.*",
     "cakephp/cakephp": "2.4.5",
-    "m6web/redis-mock": "v1.7.0"
+    "m6web/redis-mock": "v2.1.0"
   },
   "config": {
     "bin-dir": "bin"

--- a/src/FileTreeEngine.php
+++ b/src/FileTreeEngine.php
@@ -13,10 +13,16 @@ class FileTreeEngine extends FileEngine {
          $parts = str_replace(array('[', ']'), ',', $key);
          $parts = explode(',', $parts);
          
-         //get rid of trailing empty
+         //get rid of trailing empty (or beginning empty, if no prefix)
          $parts = array_diff($parts, array(''));
          
-         $prefix = $parts[0];
+         //note that if there is no prefix, the array_diff above will leave us with an array whose first index is "1"
+         if (isset($parts[0])) {
+            $prefix = $parts[0];
+         }
+         else {
+            $prefix = '';
+         }
          
          $returnVal = array();
          for($i = 1; $i < count($parts); $i++) {
@@ -42,10 +48,16 @@ class FileTreeEngine extends FileEngine {
          $parts = str_replace(array('[', ']'), ',', $key);
          $parts = explode(',', $parts);
          
-         //get rid of trailing empty
+         //get rid of trailing empty (or beginning empty, if no prefix)
          $parts = array_diff($parts, array(''));
          
-         $prefix = $parts[0];
+         //note that if there is no prefix, the array_diff above will leave us with an array whose first index is "1"
+         if (isset($parts[0])) {
+            $prefix = $parts[0];
+         }
+         else {
+            $prefix = '';
+         }
          
          $success = true;
          for($i = 1; $i < count($parts); $i++) {

--- a/src/FileTreeEngine.php
+++ b/src/FileTreeEngine.php
@@ -25,7 +25,7 @@ class FileTreeEngine extends FileEngine {
          }
 
          $returnVal = array();
-         for($i = 1; $i <= count($parts); $i++) {
+         for($i = 1; $i < count($parts); $i++) {
             $key = $prefix . $parts[$i];
 
             $returnVal[] = parent::read($key);
@@ -60,7 +60,7 @@ class FileTreeEngine extends FileEngine {
          }
 
          $success = true;
-         for($i = 1; $i <= count($parts); $i++) {
+         for($i = 1; $i < count($parts); $i++) {
             $key = $prefix . $parts[$i];
 
             if (!isset($data[$i - 1])) {

--- a/src/FileTreeEngine.php
+++ b/src/FileTreeEngine.php
@@ -3,6 +3,33 @@
 class FileTreeEngine extends FileEngine {
 
 
+   public function read($key) {
+   
+      //combo keys will be of the form: prefix_[blah,blah]
+      if (strpos($key, ',') !== false && strpos($key, '[') !== false && strpos($key, ']') !== false) {
+
+         $parts = str_replace(array(',', '[', ']'), ',', $key);
+         $parts = explode(',', $parts);
+         
+         //get rid of trailing empty
+         $parts = array_diff($parts, array(''));
+         
+         $prefix = $parts[0];
+         
+         $returnVal = array();
+         for($i = 1; $i < count($parts); $i++) {
+            $key = $prefix . $parts[$i];
+         
+            $returnVal[] = parent::read($key);
+         }
+         return $returnVal;
+      }
+      
+      return parent::read($key);
+
+   } // End function read()
+
+
    public function delete($key) {
 
       $deletedKeysCount = 0;

--- a/src/FileTreeEngine.php
+++ b/src/FileTreeEngine.php
@@ -6,16 +6,16 @@ class FileTreeEngine extends FileEngine {
     * Enhanced read to handle combo keys surrounded by brackets
     */
    public function read($key) {
-   
+
       //combo keys will be of the form: prefix_[blah,blah]; prefix is prepended by internal Cake code
       if (strpos($key, '[') !== false && substr($key, -1) == ']') {
 
          $parts = str_replace(array('[', ']'), ',', $key);
          $parts = explode(',', $parts);
-         
+
          //get rid of trailing empty (or beginning empty, if no prefix)
          $parts = array_diff($parts, array(''));
-         
+
          //note that if there is no prefix, the array_diff above will leave us with an array whose first index is "1"
          if (isset($parts[0])) {
             $prefix = $parts[0];
@@ -23,16 +23,16 @@ class FileTreeEngine extends FileEngine {
          else {
             $prefix = '';
          }
-         
+
          $returnVal = array();
-         for($i = 1; $i < count($parts); $i++) {
+         for($i = 1; $i <= count($parts); $i++) {
             $key = $prefix . $parts[$i];
-         
+
             $returnVal[] = parent::read($key);
          }
          return $returnVal;
       }
-      
+
       return parent::read($key);
 
    } // End function read()
@@ -47,10 +47,10 @@ class FileTreeEngine extends FileEngine {
 
          $parts = str_replace(array('[', ']'), ',', $key);
          $parts = explode(',', $parts);
-         
+
          //get rid of trailing empty (or beginning empty, if no prefix)
          $parts = array_diff($parts, array(''));
-         
+
          //note that if there is no prefix, the array_diff above will leave us with an array whose first index is "1"
          if (isset($parts[0])) {
             $prefix = $parts[0];
@@ -58,11 +58,11 @@ class FileTreeEngine extends FileEngine {
          else {
             $prefix = '';
          }
-         
+
          $success = true;
-         for($i = 1; $i < count($parts); $i++) {
+         for($i = 1; $i <= count($parts); $i++) {
             $key = $prefix . $parts[$i];
-         
+
             if (!isset($data[$i - 1])) {
                throw new Exception('Num keys != num values.');
             }
@@ -73,7 +73,7 @@ class FileTreeEngine extends FileEngine {
       }
 
       return parent::write($key, $data, $duration);
-   
+
    } // End function write()
 
 

--- a/src/RedisTreeEngine.php
+++ b/src/RedisTreeEngine.php
@@ -93,10 +93,16 @@ class RedisTreeEngine extends CacheEngine {
          $parts = str_replace(array('[', ']'), ',', $key);
          $parts = explode(',', $parts);
          
-         //get rid of trailing empty
+         //get rid of trailing empty (or beginning empty, if no prefix)
          $parts = array_diff($parts, array(''));
          
-         $prefix = $parts[0];
+         //note that if there is no prefix, the array_diff above will leave us with an array whose first index is "1"
+         if (isset($parts[0])) {
+            $prefix = $parts[0];
+         }
+         else {
+            $prefix = '';
+         }
          
          $keys = array();
          for($i = 1; $i < count($parts); $i++) {
@@ -173,11 +179,17 @@ class RedisTreeEngine extends CacheEngine {
 
          $parts = str_replace(array('[', ']'), ',', $key);
          $parts = explode(',', $parts);
-         
-         //get rid of trailing empty
+
+         //get rid of trailing empty (or beginning empty, if no prefix)
          $parts = array_diff($parts, array(''));
          
-         $prefix = $parts[0];
+         //note that if there is no prefix, the array_diff above will leave us with an array whose first index is "1"
+         if (isset($parts[0])) {
+            $prefix = $parts[0];
+         }
+         else {
+            $prefix = '';
+         }
          
          $returnVal = array();
          for($i = 1; $i < count($parts); $i++) {

--- a/src/RedisTreeEngine.php
+++ b/src/RedisTreeEngine.php
@@ -147,7 +147,7 @@ class RedisTreeEngine extends CacheEngine {
    /**
     * Internal single-val write.
     */
-   public function _write($key, $value, $duration) {
+   private function _write($key, $value, $duration) {
 
       if (!is_int($value)) {
         $value = serialize($value);

--- a/src/RedisTreeEngine.php
+++ b/src/RedisTreeEngine.php
@@ -314,7 +314,10 @@ class RedisTreeEngine extends CacheEngine {
 
    protected function parseMultiKey($key) {
       $matches = array();
-      preg_match("/([^\[]*)\[([^\]]+)\]/", $key, $matches);
+
+       // Multi-keys are of the form <prefix>[key1, key2]
+       // e.g., foo:[hello, world], foobar-[first, post], [no, prefix, needed]
+       preg_match("/([^\[]*)\[([^\]]+)\]/", $key, $matches);
 
       $prefix = $matches[1];
 

--- a/src/RedisTreeEngine.php
+++ b/src/RedisTreeEngine.php
@@ -92,10 +92,10 @@ class RedisTreeEngine extends CacheEngine {
 
          $parts = str_replace(array('[', ']'), ',', $key);
          $parts = explode(',', $parts);
-         
+
          //get rid of trailing empty (or beginning empty, if no prefix)
          $parts = array_diff($parts, array(''));
-         
+
          //note that if there is no prefix, the array_diff above will leave us with an array whose first index is "1"
          if (isset($parts[0])) {
             $prefix = $parts[0];
@@ -103,14 +103,14 @@ class RedisTreeEngine extends CacheEngine {
          else {
             $prefix = '';
          }
-         
+
          $keys = array();
-         for($i = 1; $i < count($parts); $i++) {
+         for($i = 1; $i <= count($parts); $i++) {
             $key = $prefix . $parts[$i];
-         
+
             $keys[] = $key;
          }
-         
+
          if (count($keys) != count($value)) {
             throw new Exception('Num keys != num values.');
          }
@@ -118,9 +118,9 @@ class RedisTreeEngine extends CacheEngine {
 
          return $this->_mwrite($key_vals, $duration);
       }
-      
+
       return $this->_write($key, $value, $duration);
-   
+
    }
 
    /**
@@ -136,7 +136,7 @@ class RedisTreeEngine extends CacheEngine {
 
       }
       unset($value);
-      
+
       if ($duration === 0) {
         return $this->redis->mset($key_value_array);
       }
@@ -182,7 +182,7 @@ class RedisTreeEngine extends CacheEngine {
 
          //get rid of trailing empty (or beginning empty, if no prefix)
          $parts = array_diff($parts, array(''));
-         
+
          //note that if there is no prefix, the array_diff above will leave us with an array whose first index is "1"
          if (isset($parts[0])) {
             $prefix = $parts[0];
@@ -190,20 +190,20 @@ class RedisTreeEngine extends CacheEngine {
          else {
             $prefix = '';
          }
-         
+
          $returnVal = array();
-         for($i = 1; $i < count($parts); $i++) {
+         for($i = 1; $i <= count($parts); $i++) {
             $key = $prefix . $parts[$i];
-         
+
             $returnVal[] = $key;//$this->_read($key);
          }
-         
-         
+
+
          return $this->_mread($returnVal);
       }
-      
+
       return $this->_read($key);
-   
+
    } // End function read()
 
    /**
@@ -212,7 +212,7 @@ class RedisTreeEngine extends CacheEngine {
    private function _mread($keys) {
 
       $items = $this->redis->mget($keys);
-      
+
       if (is_array($items)) { //should be an array...
 
          $returnVal = array();
@@ -225,18 +225,18 @@ class RedisTreeEngine extends CacheEngine {
             if ($value !== false && is_string($value)) {
               $value = unserialize($value);
             }
-         
+
             $returnVal[] = $value;
-         
+
          }
-         
+
          return $returnVal;
-      
+
       }
       else {
          throw new Exception('mget() should have returned array: ' . print_r($items, true));
       }
-      
+
       return $items;
 
    } // End function _mread()

--- a/test/FileTreeEngineTest.php
+++ b/test/FileTreeEngineTest.php
@@ -96,4 +96,33 @@ function testClear() {
 
    } // End testClear()
 
+    function testMultiWriteRead() {
+
+        $key1 = 'FileTreeEngine:TestKey:R:1';
+        $key2 = 'FileTreeEngine:TestKey:R:2';
+        $multiKey = '[' . $key1 . ',' . $key2 . ']';
+
+        $value1 = date('Y-m-d h:m') . ':1';
+        $value2 = date('Y-m-d h:m') . ':2';
+        $values = array(
+            $value1,
+            $value2
+        );
+
+        Cache::write($multiKey, $values, $this->cache);
+
+        $multiVal = Cache::read($multiKey, $this->cache);
+
+        $this->assertInternalType('array', $multiVal);
+        $this->assertEquals(2, count($multiVal));
+        $first = $multiVal[0];
+        $this->assertEquals($first, $value1);
+        $second = $multiVal[1];
+        $this->assertEquals($second, $value2);
+
+        Cache::delete($key1);
+        Cache::delete($key2);
+
+    } // End function testMultiRead()
+
 } // End class FileTreeEngineTest

--- a/test/RedisTreeEngineTest.php
+++ b/test/RedisTreeEngineTest.php
@@ -47,11 +47,40 @@ class RedisTreeEngineTest extends PHPUnit_Framework_TestCase {
    } // End function testRead()
 
 
-   function testMultiWriteRead() {
+   function testMultiWriteReadNoPrefix() {
 
       $key1 = 'RedisTreeEngine:TestKey:R:1';
       $key2 = 'RedisTreeEngine:TestKey:R:2';
       $multiKey = '[' . $key1 . ',' . $key2 . ']';
+
+      $value1 = date('Y-m-d h:m') . ':1';
+      $value2 = date('Y-m-d h:m') . ':2';
+      $values = array(
+          $value1,
+          $value2
+      );
+
+      CacheMock::write($multiKey, $values, $this->cache);
+
+      $multiVal = CacheMock::read($multiKey, $this->cache);
+
+      $this->assertInternalType('array', $multiVal);
+      $this->assertEquals(2, count($multiVal));
+      $first = $multiVal[0];
+      $this->assertEquals($first, $value1);
+      $second = $multiVal[1];
+      $this->assertEquals($second, $value2);
+
+      CacheMock::delete($key1);
+      CacheMock::delete($key2);
+
+   } // End function testMultiRead()
+
+   function testMultiWriteReadWithPrefix() {
+
+      $key1 = 'RedisTreeEngine:TestKey:R:1';
+      $key2 = 'RedisTreeEngine:TestKey:R:2';
+      $multiKey = 'alist:[' . $key1 . ',' . $key2 . ']';
 
       $value1 = date('Y-m-d h:m') . ':1';
       $value2 = date('Y-m-d h:m') . ':2';

--- a/test/RedisTreeEngineTest.php
+++ b/test/RedisTreeEngineTest.php
@@ -47,6 +47,37 @@ class RedisTreeEngineTest extends PHPUnit_Framework_TestCase {
    } // End function testRead()
 
 
+   /*
+    * This test will have to remain commented out until RedisMock supports MGET/MSET
+   function testMultiRead() {
+
+      $key1 = 'RedisTreeEngine:TestKey:R:1';
+      $value1 = date('Y-m-d h:m') . ':1';
+      CacheMock::write($key1, $value1, $this->cache);
+
+      $key2 = 'RedisTreeEngine:TestKey:R:2';
+      $value2 = date('Y-m-d h:m') . ':2';
+      CacheMock::write($key2, $value2, $this->cache);
+
+      $multiKey = '[' . $key1 . ',' . $key2 . ']';
+
+      $multiVal = CacheMock::read($multiKey, $this->cache);
+      
+      $this->assertInternalType('array', $multiVal);
+      $this->assertEquals(2, count($multiVal));
+      $first = $multiVal[0];
+      $this->assertEquals($first, $value1);
+      $second = $multiVal[1];
+      $this->assertEquals($second, $value2);
+
+      CacheMock::delete($key1);
+      CacheMock::delete($key2);
+
+   } // End function testMultiRead()
+   
+   TODO: tests for multi-write and full tests for file-tree-engine
+   */
+
    function testWrite() {
 
       $key = 'RedisTreeEngine:TestKey:W';

--- a/test/RedisTreeEngineTest.php
+++ b/test/RedisTreeEngineTest.php
@@ -47,22 +47,23 @@ class RedisTreeEngineTest extends PHPUnit_Framework_TestCase {
    } // End function testRead()
 
 
-   /*
-    * This test will have to remain commented out until RedisMock supports MGET/MSET
-   function testMultiRead() {
+   function testMultiWriteRead() {
 
       $key1 = 'RedisTreeEngine:TestKey:R:1';
-      $value1 = date('Y-m-d h:m') . ':1';
-      CacheMock::write($key1, $value1, $this->cache);
-
       $key2 = 'RedisTreeEngine:TestKey:R:2';
-      $value2 = date('Y-m-d h:m') . ':2';
-      CacheMock::write($key2, $value2, $this->cache);
-
       $multiKey = '[' . $key1 . ',' . $key2 . ']';
 
+      $value1 = date('Y-m-d h:m') . ':1';
+      $value2 = date('Y-m-d h:m') . ':2';
+      $values = array(
+          $value1,
+          $value2
+      );
+
+      CacheMock::write($multiKey, $values, $this->cache);
+
       $multiVal = CacheMock::read($multiKey, $this->cache);
-      
+
       $this->assertInternalType('array', $multiVal);
       $this->assertEquals(2, count($multiVal));
       $first = $multiVal[0];
@@ -74,9 +75,7 @@ class RedisTreeEngineTest extends PHPUnit_Framework_TestCase {
       CacheMock::delete($key2);
 
    } // End function testMultiRead()
-   
-   TODO: tests for multi-write and full tests for file-tree-engine
-   */
+
 
    function testWrite() {
 


### PR DESCRIPTION
Changes  support MGET and MSET. For Cache::read(), pass a key surrounded by brackets, comma-delimited. (e.g. "[foo,bar]"). For Cache::write(), pass a similarly structured key, and a value array (with number of elements equivalent to size of key).