### PR TITLE
Bug fix: Wrong cache prefix used in writeWithParent with FallbackEngine

### DIFF
--- a/src/CacheEnginesHelper.php
+++ b/src/CacheEnginesHelper.php
@@ -80,7 +80,12 @@ class CacheEnginesHelper
         $config = 'default',
         $parentKey = ''
     ) {
-        $settings = Cache::settings($config);
+
+        if (method_exists(Cache::engine($config), 'getActiveCacheSettings')) {
+            $settings = Cache::engine($config)->getActiveCacheSettings();
+        } else {
+            $settings = Cache::settings($config);
+        }
 
         if (empty($settings)) {
             return false;

--- a/src/FallbackEngine.php
+++ b/src/FallbackEngine.php
@@ -150,4 +150,9 @@ class FallbackEngine extends CacheEngine
     {
         return Cache::engine($this->activeCache)->key($key);
     }
+
+    public function getActiveCacheSettings()
+    {
+        return Cache::engine($this->activeCache)->settings();
+    }
 }


### PR DESCRIPTION
Ensure correct cache settings is used when writeWithParent is used with the FallbackEngine.